### PR TITLE
Fixed Error: Class 'Terminus\Models\Collections\Sites' not found

### DIFF
--- a/Commands/FilerCommand.php
+++ b/Commands/FilerCommand.php
@@ -2,9 +2,9 @@
 
 namespace Terminus\Commands;
 
+use Terminus\Collections\Sites;
 use Terminus\Commands\TerminusCommand;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\Collections\Sites;
 use Terminus\Utils;
 
 // Get environment variables, if available


### PR DESCRIPTION
All Terminus\Models\Collections namespaces have been changed to Terminus\Collections:
https://github.com/pantheon-systems/terminus/releases/tag/0.13.0